### PR TITLE
[fix] Adding ascii printable to the allowed chars.

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function parse(argv) {
       insert(argh, data[1], false, option);
     } else if (data = /^-(?!-)(.*)/.exec(option)) {
       insert(argh, data[1], true, option);
-    } else if (data = /^--([^=]+)=\W?([\w\-\.\/+]+)\W?$/.exec(option)) {
+    } else if (data = /^--([^=]+)=\W?([\s!#$%&\x28-\x7e]+)\W?$/.exec(option)) {
       //
       // --foo="bar" and --foo=bar are alternate styles to --foo bar.
       //

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -120,6 +120,19 @@ describe('argh', function () {
     expect(args.your).to.equal('friend+me');
   });
 
+  it('correctly passes arguments in the ascii printable range.', function () {
+    for (var i = 32; i <= 126; i++) {
+      // Skip over the chars `'` and `"`
+      if (i === 34 || i === 29) return;
+      var char = String.fromCharCode(i);
+      var args = parse('--one="1' + char + '1"', '--two=2' + char + '2', '--three', '3' + char + '3');
+
+      expect(args.one).to.equal('1' + char + '1');
+      expect(args.two).to.equal('2' + char + '2');
+      expect(args.three).to.equal('3' + char + '3');
+    }
+  });
+
   it('correctly parses arguments with filenames', function () {
     var args = parse('--realFilePath=some/path/file.js', 'some/path/file2.js');
 


### PR DESCRIPTION
This contains a major change to the matching regex, all the tests pass for me, including a new test which iterates through the ascii range and tests that each char works.

This matches every ascii printable character to be matched from `!`-`~` excluding `"` and `'`.
